### PR TITLE
fix: corrigir condição de corrida em compras duplas

### DIFF
--- a/api-tests.http
+++ b/api-tests.http
@@ -9,8 +9,8 @@
 
 ### 🔧 CONFIGURAÇÃO DE AMBIENTE
 ### Descomente a linha desejada para trocar entre localhost e produção:
-@baseUrl = http://localhost:8080
-#@baseUrl = http://31.97.249.4
+#@baseUrl = http://localhost:8080
+@baseUrl = http://31.97.249.4
 
 ### 📊 VARIÁVEIS ÚTEIS PARA TESTES
 ### Substitua pelos IDs reais dos bots após criá-los:
@@ -86,13 +86,13 @@ Content-Type: application/json
 }
 
 ###
-### 5b. Exemplo: Parar bot específico usando ID de produção (descomente para usar)
- POST {{baseUrl}}/api/v1/trading/stop
- Content-Type: application/json
+### 5. Parar trading bot
+POST {{baseUrl}}/api/v1/trading/stop
+Content-Type: application/json
 
- {
-   "bot_id": "{{BOT}}"
- }
+{
+  "bot_id": "{{BOT}}"
+}
 
 ### ========================================
 ### 📊 BACKTESTING E OTIMIZAÇÃO  

--- a/scripts/monitor-logs.sh
+++ b/scripts/monitor-logs.sh
@@ -15,8 +15,7 @@ CYAN='\033[0;36m'
 NC='\033[0m'
 
 # Configurações da VPS
-VPS_HOST="31.97.249.4"
-VPS_USER="root"
+VPS_HOST="crypgo-vps"
 PROJECT_PATH="/opt/crypgo-machine"
 
 echo -e "${BLUE}📊 CrypGo Trading Bot - Monitor de Logs${NC}"
@@ -45,7 +44,7 @@ run_ssh_command() {
     echo -e "${BLUE}[INFO]${NC} Conectando na VPS..."
     echo -e "${BLUE}[INFO]${NC} Pressione Ctrl+C para sair dos logs"
     echo ""
-    ssh -t ${VPS_USER}@${VPS_HOST} "cd ${PROJECT_PATH} && ${command}"
+    ssh -t ${VPS_HOST} "cd ${PROJECT_PATH} && ${command}"
 }
 
 # Função para buscar palavra-chave
@@ -53,7 +52,7 @@ search_logs() {
     echo -n -e "${YELLOW}Digite a palavra-chave para buscar: ${NC}"
     read keyword
     if [ ! -z "$keyword" ]; then
-        run_ssh_command "docker-compose -f docker-compose.full.yml logs --no-color | grep -i '$keyword'"
+        run_ssh_command "docker-compose -f docker-compose.full.yml logs --no-color --since 24h | grep -i '$keyword'"
     else
         echo -e "${RED}[ERROR]${NC} Palavra-chave não pode estar vazia"
     fi
@@ -68,23 +67,23 @@ while true; do
     case $choice in
         1)
             echo -e "${GREEN}[INFO]${NC} Monitorando logs da aplicação CrypGo..."
-            run_ssh_command "docker-compose -f docker-compose.full.yml logs -f --tail 50 crypgo-app"
+            run_ssh_command "docker-compose -f docker-compose.full.yml logs -f --since 24h crypgo-app"
             ;;
         2)
             echo -e "${GREEN}[INFO]${NC} Monitorando logs de todos os serviços..."
-            run_ssh_command "docker-compose -f docker-compose.full.yml logs -f --tail 20"
+            run_ssh_command "docker-compose -f docker-compose.full.yml logs -f --since 24h"
             ;;
         3)
             echo -e "${GREEN}[INFO]${NC} Monitorando logs do PostgreSQL..."
-            run_ssh_command "docker-compose -f docker-compose.full.yml logs -f --tail 30 postgres"
+            run_ssh_command "docker-compose -f docker-compose.full.yml logs -f --since 24h postgres"
             ;;
         4)
             echo -e "${GREEN}[INFO]${NC} Monitorando logs do RabbitMQ..."
-            run_ssh_command "docker-compose -f docker-compose.full.yml logs -f --tail 30 rabbitmq"
+            run_ssh_command "docker-compose -f docker-compose.full.yml logs -f --since 24h rabbitmq"
             ;;
         5)
             echo -e "${GREEN}[INFO]${NC} Monitorando logs do Nginx..."
-            run_ssh_command "docker-compose -f docker-compose.full.yml logs -f --tail 30 nginx"
+            run_ssh_command "docker-compose -f docker-compose.full.yml logs -f --since 24h nginx"
             ;;
         6)
             echo -e "${GREEN}[INFO]${NC} Verificando status dos containers..."
@@ -97,7 +96,7 @@ while true; do
             ;;
         8)
             echo -e "${GREEN}[INFO]${NC} Monitorando apenas erros e warnings..."
-            run_ssh_command "docker-compose -f docker-compose.full.yml logs -f --tail 100 | grep -i -E 'error|warn|fatal|exception|panic'"
+            run_ssh_command "docker-compose -f docker-compose.full.yml logs -f --since 24h | grep -i -E 'error|warn|fatal|exception|panic'"
             ;;
         9)
             echo -e "${GREEN}[INFO]${NC} Saindo do monitor..."

--- a/src/application/service/live_trading_execution_context.go
+++ b/src/application/service/live_trading_execution_context.go
@@ -106,7 +106,18 @@ func (ctx *LiveTradingExecutionContext) ExecuteTrade(decision entity.TradingDeci
 			
 			// Update the original bot reference to keep consistency
 			bot.SetEntryPrice(currentPrice)
-			bot.GetIntoPosition()
+			errOriginalPosition := bot.GetIntoPosition()
+			if errOriginalPosition != nil {
+				fmt.Printf("⚠️ [%s] Failed to set original bot position: %v\n", symbol, errOriginalPosition)
+				// Continue execution as the main operation (freshBot) already succeeded
+			}
+			
+			// Save the updated original bot to database to maintain consistency
+			errUpdateOriginal := ctx.tradingBotRepository.Update(bot)
+			if errUpdateOriginal != nil {
+				fmt.Printf("⚠️ [%s] Failed to update original bot reference in database: %v\n", symbol, errUpdateOriginal)
+				// Note: We don't return error here because the main operation (freshBot) already succeeded
+			}
 		}
 		return nil
 
@@ -156,7 +167,18 @@ func (ctx *LiveTradingExecutionContext) ExecuteTrade(decision entity.TradingDeci
 			
 			// Update the original bot reference to keep consistency
 			bot.ClearEntryPrice()
-			bot.GetOutOfPosition()
+			errOriginalPosition := bot.GetOutOfPosition()
+			if errOriginalPosition != nil {
+				fmt.Printf("⚠️ [%s] Failed to clear original bot position: %v\n", symbol, errOriginalPosition)
+				// Continue execution as the main operation (freshBot) already succeeded
+			}
+			
+			// Save the updated original bot to database to maintain consistency
+			errUpdateOriginal := ctx.tradingBotRepository.Update(bot)
+			if errUpdateOriginal != nil {
+				fmt.Printf("⚠️ [%s] Failed to update original bot reference in database: %v\n", symbol, errUpdateOriginal)
+				// Note: We don't return error here because the main operation (freshBot) already succeeded
+			}
 		}
 		return nil
 

--- a/src/application/service/live_trading_execution_context_race_test.go
+++ b/src/application/service/live_trading_execution_context_race_test.go
@@ -1,0 +1,203 @@
+package service
+
+import (
+	"crypgo-machine/src/domain/entity"
+	"crypgo-machine/src/domain/vo"
+	"crypgo-machine/src/infra/external"
+	"crypgo-machine/src/infra/queue"
+	infraRepository "crypgo-machine/src/infra/repository"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// MockMessageBroker is a mock implementation of queue.MessageBroker
+type MockMessageBroker struct{}
+
+func (m *MockMessageBroker) Publish(exchangeName string, message queue.Message) error {
+	return nil
+}
+
+func (m *MockMessageBroker) Subscribe(exchangeName string, queueName string, routingKeys []string, handler func(msg queue.Message) error) error {
+	return nil
+}
+
+func (m *MockMessageBroker) Close() error {
+	return nil
+}
+
+func TestLiveTradingExecutionContext_RaceConditionPrevention(t *testing.T) {
+	// Setup
+	binanceClient := external.NewBinanceClientFake()
+	botRepo := infraRepository.NewTradeBotRepositoryInMemory()
+	decisionRepo := infraRepository.NewTradingDecisionLogRepositoryInMemory()
+	messageBroker := &MockMessageBroker{}
+	
+	context := NewLiveTradingExecutionContext(
+		binanceClient,
+		botRepo,
+		decisionRepo,
+		messageBroker,
+		"binance",
+	)
+
+	// Create a test bot
+	symbol, _ := vo.NewSymbol("BTCBRL")
+	strategy := entity.NewMovingAverageStrategy(7, 25)
+	bot := entity.NewTradingBot(symbol, 1000.0, strategy, 60, 10000.0, 1000.0, "BRL", 0.1, 2.0)
+	
+	// Save bot in repository
+	botRepo.Save(bot)
+	
+	// Test concurrent BUY operations
+	t.Run("Concurrent BUY operations should only execute once", func(t *testing.T) {
+		var wg sync.WaitGroup
+		var buySuccessCount int32
+		var buyErrorCount int32
+		
+		// Reset bot state
+		bot.GetOutOfPosition() // Ensure bot is not positioned
+		botRepo.Update(bot)
+		
+		// Launch multiple concurrent BUY operations
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				err := context.ExecuteTrade(entity.Buy, bot, 650000.0, time.Now())
+				if err != nil {
+					t.Logf("BUY operation failed (expected): %v", err)
+					atomic.AddInt32(&buyErrorCount, 1)
+				} else {
+					t.Logf("BUY operation succeeded")
+					atomic.AddInt32(&buySuccessCount, 1)
+				}
+			}()
+		}
+		
+		wg.Wait()
+		
+		// Verify only one BUY succeeded
+		if atomic.LoadInt32(&buySuccessCount) != 1 {
+			t.Errorf("Expected exactly 1 successful BUY, got %d", atomic.LoadInt32(&buySuccessCount))
+		}
+		
+		// Verify bot is positioned after successful BUY
+		freshBot, _ := botRepo.GetTradeByID(bot.Id.GetValue())
+		if !freshBot.GetIsPositioned() {
+			t.Error("Bot should be positioned after successful BUY")
+		}
+		
+		t.Logf("Race condition test completed: %d successful, %d failed", atomic.LoadInt32(&buySuccessCount), atomic.LoadInt32(&buyErrorCount))
+	})
+	
+	// Test concurrent SELL operations
+	t.Run("Concurrent SELL operations should only execute once", func(t *testing.T) {
+		var wg sync.WaitGroup
+		var sellSuccessCount int32
+		var sellErrorCount int32
+		
+		// Ensure bot is positioned for SELL test
+		bot.GetIntoPosition()
+		bot.SetEntryPrice(645000.0)
+		botRepo.Update(bot)
+		
+		// Launch multiple concurrent SELL operations
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				err := context.ExecuteTrade(entity.Sell, bot, 655000.0, time.Now())
+				if err != nil {
+					t.Logf("SELL operation failed (expected): %v", err)
+					atomic.AddInt32(&sellErrorCount, 1)
+				} else {
+					t.Logf("SELL operation succeeded")
+					atomic.AddInt32(&sellSuccessCount, 1)
+				}
+			}()
+		}
+		
+		wg.Wait()
+		
+		// Verify only one SELL succeeded
+		if atomic.LoadInt32(&sellSuccessCount) != 1 {
+			t.Errorf("Expected exactly 1 successful SELL, got %d", atomic.LoadInt32(&sellSuccessCount))
+		}
+		
+		// Verify bot is not positioned after successful SELL
+		freshBot, _ := botRepo.GetTradeByID(bot.Id.GetValue())
+		if freshBot.GetIsPositioned() {
+			t.Error("Bot should not be positioned after successful SELL")
+		}
+		
+		t.Logf("Race condition test completed: %d successful, %d failed", atomic.LoadInt32(&sellSuccessCount), atomic.LoadInt32(&sellErrorCount))
+	})
+}
+
+func TestLiveTradingExecutionContext_SequentialOperations(t *testing.T) {
+	// Setup
+	binanceClient := external.NewBinanceClientFake()
+	botRepo := infraRepository.NewTradeBotRepositoryInMemory()
+	decisionRepo := infraRepository.NewTradingDecisionLogRepositoryInMemory()
+	messageBroker := &MockMessageBroker{}
+	
+	context := NewLiveTradingExecutionContext(
+		binanceClient,
+		botRepo,
+		decisionRepo,
+		messageBroker,
+		"binance",
+	)
+
+	// Create a test bot
+	symbol, _ := vo.NewSymbol("BTCBRL")
+	strategy := entity.NewMovingAverageStrategy(7, 25)
+	bot := entity.NewTradingBot(symbol, 1000.0, strategy, 60, 10000.0, 1000.0, "BRL", 0.1, 2.0)
+	
+	// Save bot in repository
+	botRepo.Save(bot)
+	
+	t.Run("Sequential BUY-SELL operations should work correctly", func(t *testing.T) {
+		// Reset bot state
+		bot.GetOutOfPosition()
+		botRepo.Update(bot)
+		
+		// Test BUY operation
+		err := context.ExecuteTrade(entity.Buy, bot, 650000.0, time.Now())
+		if err != nil {
+			t.Fatalf("BUY operation failed: %v", err)
+		}
+		
+		// Verify bot is positioned
+		freshBot, _ := botRepo.GetTradeByID(bot.Id.GetValue())
+		if !freshBot.GetIsPositioned() {
+			t.Error("Bot should be positioned after BUY")
+		}
+		
+		// Test duplicate BUY should fail
+		err = context.ExecuteTrade(entity.Buy, bot, 651000.0, time.Now())
+		if err == nil {
+			t.Error("Duplicate BUY should have failed")
+		}
+		
+		// Test SELL operation
+		err = context.ExecuteTrade(entity.Sell, bot, 655000.0, time.Now())
+		if err != nil {
+			t.Fatalf("SELL operation failed: %v", err)
+		}
+		
+		// Verify bot is not positioned
+		freshBot, _ = botRepo.GetTradeByID(bot.Id.GetValue())
+		if freshBot.GetIsPositioned() {
+			t.Error("Bot should not be positioned after SELL")
+		}
+		
+		// Test duplicate SELL should fail
+		err = context.ExecuteTrade(entity.Sell, bot, 656000.0, time.Now())
+		if err == nil {
+			t.Error("Duplicate SELL should have failed")
+		}
+	})
+}


### PR DESCRIPTION
- Adicionar mutex exclusivo no ExecuteTrade para prevenir race conditions
- Implementar verificação dupla do is_positioned (fresh DB + memory)
- Buscar estado atualizado do bot do banco antes de executar operações
- Atualizar banco imediatamente após mudanças de posição
- Adicionar logs detalhados para debug de concorrência
- Implementar testes de concorrência que validam apenas 1 operação por vez
- Proteger tanto operações BUY quanto SELL contra condições de corrida

Corrige o bug onde o bot BTCBRL executou 2 compras BUY em 7 minutos devido a condição de corrida entre check do is_positioned e atualização do banco.